### PR TITLE
mention team-rate and subcontracting

### DIFF
--- a/running-projects-via-the-collective.md
+++ b/running-projects-via-the-collective.md
@@ -1,20 +1,24 @@
 # Running projects via the collective
 
-- We wanna run via the collective BV the projects that require more than 1 fikaworks member
-- The invoicing and money flow will be: `customer` ->  `fikaworks BV` -> `members BV ( or external contractors)`
-- There will be an contract between client and fikaworks BV and a different contract between the fikaworks BV and the external contractors
+- We will run via the collective limited liability company (BV) the projects that require more than 1 FikaWorks member
+- The invoicing and money flow will be: `customer` ->  `fikaworks BV` -> `member company (or external contractor)`
+- There will be a contract between client and FikaWorks BV and a different contract between FikaWorks BV and the members (or external contractors)
+- The contract terms between FikaWorks and the members (external contractors) will mirror the contract terms between customer and FikaWorks (scope of work, notice period, etc)
+- The members (external contractors) are not allowed to sub-contarct their work to 3rd parties.
+- The liability will always be passed to the members (external contractors) that are executing the project.
 
 ## Distributing projects
 - Jobs will go first to the collective members and then will be shared with the broader slack community (called here contractors)
 
 ## Project Financials
 
-- Fee for external contractors/fikaworks cummunity members: 10% (for the first 3 months)
+- Fee for external contractors/fikaworks community members: 10% (for the first 3 months of the project). The fee will be used to cover admin costs (invoicing, FikaWorks logistics) and sales effort.
 - We can pay back the fee if the contractor/community member joins the collective as a full member (in 1 year)
 - Incubating members will not pay a fee
 - Minimum rate for executing a project: [confidential] euro
 - Minimum asking rate [confidential] euro
 - Exception for accepting lower rates to be discussed in the collective
+- For projects with 2 or more members we will charge the same rate for everybody (negociate a team rate).
 
 ## Dropping projects procedure
 - Exit clause (from members/contractors) should to match client contract


### PR DESCRIPTION
I've added a few additions to the contracts page based on what we learned from running the first project via the coop.
- stress that all contracts with more than 1 members should run via the coop
- mention that the contract terms are passed to the members/contractors, same for liability
- mention that projects can't be subcontracted
- mentioned why we charge 10% from externals
- settle on standard rate for team projects (to avoid friction) and to simplify it for customers 

Please let me know if there are any concerns or if you wanna add extra stuff, this is just a proposal. 
Also, I'm in favour of setting a max rate (TBD) paid to externals because our rates are usually higher that regular freelance gigs. That can help us build a buffer or help us keep the members costs low.